### PR TITLE
Fix svg progress and click behavior

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -95,6 +95,7 @@ if (document.body.classList.contains('resources-page')) {
   const checkpoints = Array.from(document.querySelectorAll('.checkpoint'));
   const fog = document.querySelector('.fog-mask');
   const glowStop = document.getElementById('glow-stop');
+  const glowCut = document.getElementById('glow-cut');
 
   // Apply absolute positions from data attributes
   checkpoints.forEach(cp => {
@@ -145,8 +146,15 @@ if (document.body.classList.contains('resources-page')) {
       const xpct = parseFloat(cp.getAttribute('data-xpct') || '0');
       pct = Math.max(pct, xpct);
     });
+    // If all checkpoints completed, force 100%
+    const allCompleted = progress.length >= ordered.length && ordered.length > 0;
+    if (allCompleted) pct = 100;
+
+    // Set a hard cutoff so the glow fills from the very left to `pct`.
+    if (glowCut) glowCut.setAttribute('offset', `${pct}%`);
     if (glowStop) glowStop.setAttribute('offset', `${pct}%`);
-    // Fog only at the last card area
+
+    // Keep fog mask logic as-is (reveal around the last card area)
     const last = ordered[ordered.length - 1];
     const lastPct = last ? parseFloat(last.getAttribute('data-xpct') || '100') : 100;
     const reveal = Math.min(99, lastPct);

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -36,9 +36,11 @@
       <div id="road-scroll" style="overflow-x: auto; overflow-y: hidden; padding-bottom: 8px; -webkit-overflow-scrolling: touch;">
         <svg id="road-svg" class="roadmap-svg" viewBox="0 0 {{ canvas_width }} {{ svg_height }}" preserveAspectRatio="xMidYMid meet" data-canvas-width="{{ canvas_width }}" data-svg-height="{{ svg_height }}" style="min-width: {{ canvas_width }}px;">
           <defs>
-            <linearGradient id="pathGlow" x1="0%" y1="0%" x2="100%" y2="0%">
+            <linearGradient id="pathGlow" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="{{ canvas_width }}" y2="0">
               <stop offset="0%" stop-color="#22d3ee"/>
+              <stop id="glow-cut" offset="0%" stop-color="#22d3ee"/>
               <stop id="glow-stop" offset="0%" stop-color="#334155"/>
+              <stop offset="100%" stop-color="#334155"/>
             </linearGradient>
           </defs>
           {% for bp in branch_paths %}


### PR DESCRIPTION
Adjust SVG progress bar to fill from the left edge and reach 100% completion.

Previously, the progress bar's glow did not start from the far left and failed to fully fill the bar even when all checkpoints were marked as complete. This change ensures the visual progress accurately reflects the completion status.

---
<a href="https://cursor.com/background-agent?bcId=bc-4abebcaa-1be0-4923-b684-95a728262fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4abebcaa-1be0-4923-b684-95a728262fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

